### PR TITLE
Pre-Migration: Fix logic issue in AcquireAccessToken caching

### DIFF
--- a/pre-migration/source-code/AADB2C.GraphService/B2CGraphClient.cs
+++ b/pre-migration/source-code/AADB2C.GraphService/B2CGraphClient.cs
@@ -243,7 +243,7 @@ namespace AADB2C.GraphService
         {
             // If the access token is null or about to be invalid, acquire new one
             if (B2CGraphClient.AccessToken == null ||
-                (B2CGraphClient.AccessToken.ExpiresOn.UtcDateTime > DateTime.UtcNow.AddMinutes(-10)))
+                (B2CGraphClient.AccessToken.ExpiresOn.UtcDateTime < DateTime.UtcNow.AddMinutes(10)))
             {
                 try
                 {


### PR DESCRIPTION
Logic issue in caching logic comparing expiration date on access token.

Fix saves about 150 ms per call from east us to get an access token.  Looping over 2000 graph calls saved me ~30 - 45 seconds.