### PR TITLE
Added new grant_type metadata item to ROPC TechnicalProfile

### DIFF
--- a/jit-migration-v1/policy/TrustFrameworkBase.xml
+++ b/jit-migration-v1/policy/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/jit-migration-v2/policy/TrustFrameworkBase.xml
+++ b/jit-migration-v2/policy/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>

--- a/pre-migration/policy/TrustFrameworkBase.xml
+++ b/pre-migration/policy/TrustFrameworkBase.xml
@@ -501,6 +501,7 @@
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>
+            <Item Key="grant_type">password</Item>
 
             <!-- Policy Engine Clients -->
             <Item Key="UsePolicyInRedirectUri">false</Item>


### PR DESCRIPTION
This is an update to the docs for B2C custom policies adding a grant_type metadata item to ROPC-based technical profiles. Adding this metadata item enables Just-in-time migration via ROPC and REST. See [here](https://github.com/Azure-Samples/active-directory-b2c-custom-policy-starterpack/pull/65) for further details.

This is already in the official B2C docs and should be considered the part of the default base policy.

Additionally, this repo seems to have similar problems described [here](https://github.com/azure-ad-b2c/samples/pull/106) and also needs a `.gitignore` file.  However, I shall leave that all up to the maintainers as I have found [yet _more_ repositories](https://github.com/search?q=org%3Aazure-ad-b2c+InputClaim+ClaimTypeReferenceId%3D%22grant_type&type=Code) to which this change has not yet found its way.