### PR TITLE
fix bug where emails with plus (+) symbol fail to sync

### DIFF
--- a/pre-migration/source-code/AADB2C.GraphService/B2CGraphClient.cs
+++ b/pre-migration/source-code/AADB2C.GraphService/B2CGraphClient.cs
@@ -120,9 +120,9 @@ namespace AADB2C.GraphService
         public async Task<string> SearcUserBySignInNames(string signInNames)
         {
             var signInNamesEncoded = HttpUtility.UrlEncode(signInNames);
-            return GraphAccounts.Parse(await SendGraphRequest("/users/",
+            return await SendGraphRequest("/users/",
                             $"$filter=signInNames/any(x:x/value eq '{signInNamesEncoded}')",
-                            null, HttpMethod.Get));
+                            null, HttpMethod.Get);
         }
 
         /// <summary>

--- a/pre-migration/source-code/AADB2C.GraphService/B2CGraphClient.cs
+++ b/pre-migration/source-code/AADB2C.GraphService/B2CGraphClient.cs
@@ -119,9 +119,10 @@ namespace AADB2C.GraphService
         /// </summary>
         public async Task<string> SearcUserBySignInNames(string signInNames)
         {
-            return await SendGraphRequest("/users/",
-                            $"$filter=signInNames/any(x:x/value eq '{signInNames}')",
-                            null, HttpMethod.Get);
+            var signInNamesEncoded = HttpUtility.UrlEncode(signInNames);
+            return GraphAccounts.Parse(await SendGraphRequest("/users/",
+                            $"$filter=signInNames/any(x:x/value eq '{signInNamesEncoded}')",
+                            null, HttpMethod.Get));
         }
 
         /// <summary>


### PR DESCRIPTION
After using this code in production, found an issue where emails with a + symbol (or any other funky symbol) cause sync to fail.
Fix: add url encoding for this request only (since it should be the only one with funky symbols)